### PR TITLE
Fixed for TWW Pre-Patch and added Blacklist feature (hardcoded for now!)

### DIFF
--- a/src/AbandonAllQuests.lua
+++ b/src/AbandonAllQuests.lua
@@ -80,9 +80,9 @@ function AbandonAllQuests_abandonAllQuestsConfirm()
             DEFAULT_CHAT_FRAME:AddMessage(format(namespace.AbandonAllQuests_GetTranslation("SKIPPED_QUEST"), questInfo.title), 1.0, 0.3, 0.0)
         elseif questInfo.questID ~= 0 and not questInfo.isHeader and not questInfo.isHidden and not tableContains(blacklist, questInfo.questID) then
             DEFAULT_CHAT_FRAME:AddMessage(format(namespace.AbandonAllQuests_GetTranslation("ABANDON_QUEST_SUCCESS"), questInfo.title), 1.0, 1.0, 0.0)
-            --C_QuestLog.SetSelectedQuest(questInfo.questID)
-            --C_QuestLog.SetAbandonQuest()
-            --C_QuestLog.AbandonQuest()
+            C_QuestLog.SetSelectedQuest(questInfo.questID)
+            C_QuestLog.SetAbandonQuest()
+            C_QuestLog.AbandonQuest()
         end
     end
 end

--- a/src/AbandonAllQuests.lua
+++ b/src/AbandonAllQuests.lua
@@ -1,32 +1,44 @@
 local ADDON_NAME, namespace = ...
 
-local frame = CreateFrame("FRAME");
-frame:RegisterEvent("ADDON_LOADED");
-frame:RegisterEvent("QUEST_LOG_UPDATE");
-frame:RegisterEvent("QUEST_FINISHED");
-frame:RegisterEvent("QUEST_COMPLETE");
+local frame = CreateFrame("FRAME")
+frame:RegisterEvent("ADDON_LOADED")
+frame:RegisterEvent("QUEST_LOG_UPDATE")
+frame:RegisterEvent("QUEST_FINISHED")
+frame:RegisterEvent("QUEST_COMPLETE")
 
-local button = CreateFrame("Button", "AbandonAllQuests_AbandonButton", QuestScrollFrame.DetailFrame, "SharedButtonTemplate");
+local blacklist = namespace.BlackListTable or {}
 
-function AbandonAllQuests_hideButton() 
+-- Check if "value {v}" already exists in "table {t}"
+local function tableContains(t, v)
+    for _, item in ipairs(t) do
+        if item == v then
+            return true
+        end
+    end
+    return false
+end
+
+local button = CreateFrame("Button", "AbandonAllQuests_AbandonButton", QuestScrollFrame.Contents, "SharedButtonTemplate")
+
+function AbandonAllQuests_hideButton()
     button:Hide()
 end
 
-function AbandonAllQuests_showButton() 
+function AbandonAllQuests_showButton()
     button:Show()
 end
 
-function frame:OnEvent(event, arg1) 
-    if event == "ADDON_LOADED" and arg1 == "AbandonAllQuests" then
+function frame:OnEvent(event, arg1)
+    if event == "ADDON_LOADED" and arg1 == ADDON_NAME then
         local buttonHeight = 24
-        local mapButtonLabel = namespace.AbandonAllQuests_GetTranslation("MAP_BUTTON_LABEL");
-        button:SetFrameStrata("DIALOG");
+        local mapButtonLabel = namespace.AbandonAllQuests_GetTranslation("MAP_BUTTON_LABEL")
+        button:SetFrameStrata("DIALOG")
         button:SetWidth(264)
         -- button:SetWidth(strlen(mapButtonLabel) * 8) -- Variable button width based on text length
         button:SetHeight(buttonHeight)
         button:SetText(mapButtonLabel)
-        button:SetPoint("BOTTOM",0,1)
-        -- button:SetPoint("BOTTOM",0,-buttonHeight/2) -- Vertical position
+        button:SetPoint("BOTTOM", 0, -40)
+        -- button:SetPoint("BOTTOM", 0, -buttonHeight/2) -- Vertical position
         button:SetScript("OnClick", AbandonAllQuests_abandonAllQuestsRequest)
         button:Show()
 
@@ -41,35 +53,36 @@ function frame:OnEvent(event, arg1)
             preferredIndex = 3,
         }
 
-        else if event == "QUEST_LOG_UPDATE" or event == "QUEST_FINISHED" or event == "QUEST_COMPLETE" then 
-            local questsAvailable = false;
-            for i=1,C_QuestLog.GetNumQuestLogEntries() do 
-                local questInfo = C_QuestLog.GetInfo(i);
-                if (not questInfo.isHeader and not questInfo.isHidden) then
-                    questsAvailable = true;
-                    break;
-                end
-            end
-
-            if questsAvailable then 
-                AbandonAllQuests_showButton() 
-            else 
-                AbandonAllQuests_hideButton()
+    elseif event == "QUEST_LOG_UPDATE" or event == "QUEST_FINISHED" or event == "QUEST_COMPLETE" then
+        local questsAvailable = false
+        for i = 1, C_QuestLog.GetNumQuestLogEntries() do
+            local questInfo = C_QuestLog.GetInfo(i)
+            if not questInfo.isHeader and not questInfo.isHidden then
+                questsAvailable = true
+                break
             end
         end
-    end
 
+        if questsAvailable then
+            AbandonAllQuests_showButton()
+        else
+            AbandonAllQuests_hideButton()
+        end
+    end
 end
-frame:SetScript("OnEvent", frame.OnEvent);
+
+frame:SetScript("OnEvent", frame.OnEvent)
 
 function AbandonAllQuests_abandonAllQuestsConfirm()
-    for i=1,C_QuestLog.GetNumQuestLogEntries() do 
-        local questInfo = C_QuestLog.GetInfo(i);
-        if (not questInfo.isHeader and not questInfo.isHidden) then
-            DEFAULT_CHAT_FRAME:AddMessage(format(namespace.AbandonAllQuests_GetTranslation("ABANDON_QUEST_SUCCESS"), questInfo.title), 1.0, 1.0, 0.0);
-            C_QuestLog.SetSelectedQuest(questInfo.questID); 
-            C_QuestLog.SetAbandonQuest(); 
-            C_QuestLog.AbandonQuest()    
+    for i = 1, C_QuestLog.GetNumQuestLogEntries() do
+        local questInfo = C_QuestLog.GetInfo(i)
+        if tableContains(blacklist, questInfo.questID) then
+            DEFAULT_CHAT_FRAME:AddMessage(format(namespace.AbandonAllQuests_GetTranslation("SKIPPED_QUEST"), questInfo.title), 1.0, 0.3, 0.0)
+        elseif questInfo.questID ~= 0 and not questInfo.isHeader and not questInfo.isHidden and not tableContains(blacklist, questInfo.questID) then
+            DEFAULT_CHAT_FRAME:AddMessage(format(namespace.AbandonAllQuests_GetTranslation("ABANDON_QUEST_SUCCESS"), questInfo.title), 1.0, 1.0, 0.0)
+            --C_QuestLog.SetSelectedQuest(questInfo.questID)
+            --C_QuestLog.SetAbandonQuest()
+            --C_QuestLog.AbandonQuest()
         end
     end
 end

--- a/src/AbandonAllQuests.toc
+++ b/src/AbandonAllQuests.toc
@@ -1,8 +1,9 @@
-## Interface: 10000
+## Interface: 110002
 ## Title: AbandonAllQuests
 ## Notes: Remove all quests from your quest log with the click of a button
 ## Author: scholle
-## Version: 1.0.1
+## Version: 1.0.2
 
+Blacklist.lua
 AbandonAllQuests.lua
 Locale.lua

--- a/src/Blacklist.lua
+++ b/src/Blacklist.lua
@@ -3,7 +3,8 @@ local ADDON_NAME, namespace = ...
 namespace.BlackListTable = {
 	24756, -- Blood Infusion (DK Legendary Quest from WotLK)
 
-	29433, -- Test Your Strength (Darkmoon Quest)
+	29507, -- Fun for the Little Ones (Darkmoon Archeology Quest)
+	29433, -- Test Your Strength (Darkmoon Quest)	
 
 	78421, -- The Power of Dreams, Amirdrasil Quest for Head Enchant
 

--- a/src/Blacklist.lua
+++ b/src/Blacklist.lua
@@ -2,24 +2,38 @@ local ADDON_NAME, namespace = ...
 
 namespace.BlackListTable = {
 	24756, -- Blood Infusion (DK Legendary Quest from WotLK)
-	
+
 	29433, -- Test Your Strength (Darkmoon Quest)
+
+	78421, -- The Power of Dreams, Amirdrasil Quest for Head Enchant
+
+	----------------------------------------------
+	-- all possible "Skipping Quests" for Raids --
+	----------------------------------------------
 
 	37029, -- Blackrock Foundry (Normal)
 	37030, -- Blackrock Foundry (Heroic)
 	37031, -- Blackrock Foundry (Mythic)
 
-	39499, -- Hellfire Citadel (Normal)
-	39500, -- Hellfire Citadel (Heroic)
-	39501, -- Hellfire Citadel (Mythic)
+	39499, -- Hellfire Citadel: Well of Souls (Normal)
+	39500, -- Hellfire Citadel: Well of Souls (Heroic)
+	39501, -- Hellfire Citadel: Well of Souls (Mythic)
 
-	45381, -- Nighthold (Normal)
-	45382, -- Nighthold (Heroic)
-	45383, -- Nighthold (Mythic)
+	39502, -- Hellfire Citadel: The Fel Spire (Normal)
+	39504, -- Hellfire Citadel: The Fel Spire (Heroic)
+	39505, -- Hellfire Citadel: The Fel Spire (Mythic)
 
-	47725, -- Tomb of Sargeras (Normal)
-	47726, -- Tomb of Sargeras (Heroic)
-	47727, -- Tomb of Sargeras (Mythic)
+	44283, -- The Emerald Nightmare: Piercing the Veil (Normal)
+	44284, -- The Emerald Nightmare: Piercing the Veil (Heroic)
+	44285, -- The Emerald Nightmare: Piercing the Veil (Mythic)
+
+	45381, -- The Nighthold: Talisman of the Shal'dorei (Normal)
+	45382, -- The Nighthold: Talisman of the Shal'dorei (Heroic)
+	45383, -- The Nighthold: Talisman of the Shal'dorei (Mythic)
+
+	47725, -- Tomb of Sargeras: Aegwynn's Path (Normal)
+	47726, -- Tomb of Sargeras: Aegwynn's Path (Heroic)
+	47727, -- Tomb of Sargeras: Aegwynn's Path (Mythic)
 
 	49032, -- Antorus, the Burning Throne: Dark Passage (Normal)
 	49075, -- Antorus, the Burning Throne: Dark Passage (Heroic)
@@ -29,9 +43,27 @@ namespace.BlackListTable = {
 	49134, -- Antorus, the Burning Throne: The Heart of Argus (Heroic)
 	49135, -- Antorus, the Burning Throne: The Heart of Argus (Mythic)
 
+	58373, -- Ny'alotha: MOTHER's Guidance (Normal)
+	58374, -- Ny'alotha: MOTHER's Guidance (Heroic)
+	58375, -- Ny'alotha: MOTHER's Guidance (Mythic)
+
 	64597, -- Sanctum of Domination (Normal)
 	64598, -- Sanctum of Domination (Heroic)
 	64599, -- Sanctum of Domination (Mythic)
 
-	78421  -- The Power of Dreams, Amirdrasil Quest for Head Enchant
+	65762, -- Sepulcher of the First Ones - Heavy is the Crown (Mythic)
+	65763, -- Sepulcher of the First Ones - Heavy is the Crown (Heroic)
+	65764, -- Sepulcher of the First Ones - Heavy is the Crown (Normal)
+
+	71018, -- Vault of the Incarnates: Break a Few Eggs (Normal)
+	71019, -- Vault of the Incarnates: Break a Few Eggs (Heroic)
+	71020, -- Vault of the Incarnates: Break a Few Eggs (Mythic)
+
+	76083, -- Aberrus, the Shadowed Crucible: Echoes of the Earth-Warder (Normal)
+	76085, -- Aberrus, the Shadowed Crucible: Echoes of the Earth-Warder (Heroic)
+	76086, -- Aberrus, the Shadowed Crucible: Echoes of the Earth-Warder (Mythic)
+
+	78600, -- Amirdrassil, the Dream's Hope: Up in Smoke (Normal)
+	78601, -- Amirdrassil, the Dream's Hope: Up in Smoke (Heroic)
+	78602  -- Amirdrassil, the Dream's Hope: Up in Smoke (Mythic)
 }

--- a/src/Blacklist.lua
+++ b/src/Blacklist.lua
@@ -1,0 +1,37 @@
+local ADDON_NAME, namespace = ...
+
+namespace.BlackListTable = {
+	24756, -- Blood Infusion (DK Legendary Quest from WotLK)
+	
+	29433, -- Test Your Strength (Darkmoon Quest)
+
+	37029, -- Blackrock Foundry (Normal)
+	37030, -- Blackrock Foundry (Heroic)
+	37031, -- Blackrock Foundry (Mythic)
+
+	39499, -- Hellfire Citadel (Normal)
+	39500, -- Hellfire Citadel (Heroic)
+	39501, -- Hellfire Citadel (Mythic)
+
+	45381, -- Nighthold (Normal)
+	45382, -- Nighthold (Heroic)
+	45383, -- Nighthold (Mythic)
+
+	47725, -- Tomb of Sargeras (Normal)
+	47726, -- Tomb of Sargeras (Heroic)
+	47727, -- Tomb of Sargeras (Mythic)
+
+	49032, -- Antorus, the Burning Throne: Dark Passage (Normal)
+	49075, -- Antorus, the Burning Throne: Dark Passage (Heroic)
+	49076, -- Antorus, the Burning Throne: Dark Passage (Mythic)
+
+	49133, -- Antorus, the Burning Throne: The Heart of Argus (Normal)
+	49134, -- Antorus, the Burning Throne: The Heart of Argus (Heroic)
+	49135, -- Antorus, the Burning Throne: The Heart of Argus (Mythic)
+
+	64597, -- Sanctum of Domination (Normal)
+	64598, -- Sanctum of Domination (Heroic)
+	64599, -- Sanctum of Domination (Mythic)
+
+	78421  -- The Power of Dreams, Amirdrasil Quest for Head Enchant
+}

--- a/src/Locale.lua
+++ b/src/Locale.lua
@@ -7,12 +7,14 @@ translations.enUS = {
     MAP_BUTTON_LABEL = "Abandon all quests",
     ABANDON_DIALOG_QUESTION = "Are you sure you want to abandon all quests?",
     ABANDON_QUEST_SUCCESS = "Abandoned quest: %s",
+    SKIPPED_QUEST = "Skipped quest: %s",
 }
 
 translations.deDE = {
     MAP_BUTTON_LABEL = "Alle Quests abbrechen",
     ABANDON_DIALOG_QUESTION = "Bist du sicher, dass du alle Quests abbrechen willst?",
     ABANDON_QUEST_SUCCESS = "Quest abgebrochen: %s",
+		SKIPPED_QUEST = "Quest übersprungen: %s",
 }
 
 function AbandonAllQuests_GetTranslation(key) 


### PR DESCRIPTION
Fixed for TWW Pre-Patch, now you need to scroll ALL THE WAY down your Qeustlog to Click the "Abandon All" Button

Added Simple "BlackList" feature!
Currently hardcoded and need to be changed inside the "Blacklist.lua" in the AddOn Folder of "AbandonAllQuests"

Added Translation Lines for Blacklist/Skipped Quests